### PR TITLE
Add ability to check json and zookeeper

### DIFF
--- a/health_checker.py
+++ b/health_checker.py
@@ -35,13 +35,15 @@ def log(param):
 
 def config(conf):
     global plugin_conf
-    required_keys = ('Instance', 'HEALTH_URL')
+    required_keys = ('Instance', 'URL')
     json_keys = ('JSONKey', 'JSONVal')
     chk_json = False
     bad_conf = 0
 
     for val in conf.children:
         if val.key == 'HEALTH_URL':
+            plugin_conf['URL'] = val.values[0]
+        elif val.key == 'URL':
             plugin_conf[val.key] = val.values[0]
         elif val.key == 'JSONKey':
             plugin_conf[val.key] = val.values[0]
@@ -73,7 +75,7 @@ def _get_health_status(plugin_conf):
     status = 0
     val = 0
     r = None
-    health_url = plugin_conf.get('HEALTH_URL')
+    health_url = plugin_conf.get('URL')
     json_key = plugin_conf.get('JSONKey')
     json_val = plugin_conf.get('JSONVal')
     try:
@@ -110,7 +112,7 @@ def read():
         log('Invalid config keys found.  Will not collect metrics')
         return
 
-    if 'HEALTH_URL' in plugin_conf:
+    if 'URL' in plugin_conf:
         sval, hval = _get_health_status(plugin_conf)
 
     if sval is not None and hval is not None:


### PR DESCRIPTION
This change adds the ability to parse json  and to do zookeeper checks.  The logic for both of these is copied from the customized checks that we configured in Nagios.  The curl_json plugin doesn't fully replicate our customized Nagios check, which is what prompted this.

Since we have three types of health checks now, I abstracted out their success/failures so that they all return the same metric value.  If there is a failure, i log it in the collectd logs.  This allows all health checks for any component to report the same metric, so we can include it all in the same chart.  Also, this reports two types of metrics, which can be combined into one alert.   If it turns out this is a bad idea, i can split things out into separate plugins.

Since I'm new to writing the plugin, i'm still working on ensuring that both JSON keys are present in a config file but i wanted to get this to you all now so i can work on that in the meantime while doing code review requests - also, i'll be sending a salt diff via phab soon
